### PR TITLE
Custom Properties prototype

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -73,6 +73,7 @@ Standard: "c++20"
 TabWidth: 4
 UseTab: Never
 UseCRLF: false
+LineEnding: LF
 ---
 Language: ObjC
 BasedOnStyle: Chromium

--- a/melatonin/components/properties.h
+++ b/melatonin/components/properties.h
@@ -84,7 +84,26 @@ namespace melatonin
             auto enabled = new juce::BooleanPropertyComponent (model.enabledValue, "Enabled", "");
             enabled->setEnabled (false);
 
-            return {
+            juce::Array<juce::PropertyComponent*> props;
+
+            for (size_t i = 0; i < model.customKeys.size(); ++i)
+            {
+                auto name = model.customKeys[i].getValue().toString();
+                auto value = model.customValues[i].getValue();
+                if (value.isBool())
+                {
+                    auto prop = new juce::BooleanPropertyComponent (model.customValues[i], name, "");
+                    prop->setEnabled (false);
+                    props.add (prop);
+                }
+                else
+                {
+                    auto prop = new juce::TextPropertyComponent (model.customValues[i], name, 200, false, false);
+                    props.add (prop);
+                }
+            }
+
+            props.addArray (juce::Array<juce::PropertyComponent*> {
                 new juce::TextPropertyComponent (model.typeValue, "Class", 200, false, false),
                 new juce::TextPropertyComponent (model.lookAndFeelValue, "LookAndFeel", 200, false, false),
                 new juce::TextPropertyComponent (model.xValue, "X", 5, false),
@@ -99,8 +118,8 @@ namespace melatonin
                 accessibilityHandled,
                 cachedImage,
                 interceptsMouse,
-                childrenInterceptsMouse
-            };
+                childrenInterceptsMouse });
+            return props;
         }
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Properties)

--- a/melatonin/helpers/misc.h
+++ b/melatonin/helpers/misc.h
@@ -34,4 +34,20 @@ namespace melatonin
         }
     }
 
+    // see ComponentModel::populateCustomValues
+    static void setCustomInspectorProperty (juce::Component* component, juce::String key, juce::var value)
+    {
+        auto& props = component->getProperties();
+
+        // allow up to 10 custom properties for now
+        for (auto i = 1; i < 11; ++i)
+        {
+            if (!props.contains ("inspectorPropertyName" + juce::String (i)))
+            {
+                props.set ("inspectorPropertyName" + juce::String (i), key);
+                props.set ("inspectorPropertyValue" + juce::String (i), value);
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Here's a rough implementation of custom properties. The idea is to call this helper from your component:

```cpp
// someComponent.h
#include "melatonin_inspector/melatonin/helpers/misc.h"
.
.
.
        melatonin::setCustomInspectorProperty(this, "Flavor", flavorNames[static_cast<int> (flavor)]);
        melatonin::setCustomInspectorProperty(this, "Theme Key", themeKey);
```

Each call adds 2 properties to the component, for example `inspectorPropertyName1` and `inspectorPropertyValue1`  which then show up at the top of the property inspector:

![AudioPluginHost - 2023-08-03 25@2x](https://github.com/sudara/melatonin_inspector/assets/472/50baf145-9480-4a33-8b24-3ea9a1962101)

@dikadk / @FigBug would either of you use this or have implementation opinions?

Implementation Qs:

* perhaps there's a more elegant naming convention for custom properties (vs. incrementing integers)
* including an inspector header is sort of over the top considering it just adds some props (vs. being an actual hook into the inspector, which could be more elegant)
* hard coded a limit of 10 properties

This isn't the first time I've wished a JUCE Component's properties were backed by a first class data store vs a flat `NamedValueSet`..