### PR TITLE
Fix gcc Wimplicit-int-float-conversion.

### DIFF
--- a/melatonin/components/overlay.h
+++ b/melatonin/components/overlay.h
@@ -373,7 +373,7 @@ namespace melatonin
             if (selectedComponent && hoveredComponent)
             {
                 int labelHeight = 15;
-                auto paddingToLabel = 4;
+                auto paddingToLabel = 4.0f;
 
                 // top
                 if (lineToTopHoveredComponent.getLength() > 0)


### PR DESCRIPTION
GCC 13.2 on Fedora

