### PR TITLE
Fix crash when closing colour component

### DIFF
--- a/melatonin/components/colour_property_component.h
+++ b/melatonin/components/colour_property_component.h
@@ -112,9 +112,12 @@ namespace melatonin
                     colourSelector->setLookAndFeel (&getLookAndFeel());
                     colourSelector->setSize (300, 300);
                     colourSelector->setCurrentColour (juce::Colour ((uint32_t) int (value.getValue())), juce::dontSendNotification);
-                    colourSelector->onDismiss = [this, cs = colourSelector.get()]() {
-                        value = (int) cs->getCurrentColour().getARGB();
-                        repaint();
+                    colourSelector->onDismiss = [this, parentRef = juce::WeakReference<juce::Component> (this), cs = colourSelector.get()]() {
+                        if (! parentRef.wasObjectDeleted())
+                        {
+                            value = (int) cs->getCurrentColour().getARGB();
+                            repaint();
+                        }
                     };
                     colourSelector->onChange = [this, cs = colourSelector.get()]() {
                         value = (int) cs->getCurrentColour().getARGB();


### PR DESCRIPTION
I noticed that when the colour component is open and you click on one of these buttons than the `onDismiss` callback is invoked but refers to its parent which has been destroyed already it seems.

![Screenshot 2023-11-07 at 16 36 33](https://github.com/sudara/melatonin_inspector/assets/77342446/9fbde125-e27a-4143-b0b0-2e505df05bf8)