### PR TITLE
Accesibility Change One: Show Acessible Info

### DIFF
--- a/melatonin/component_model.h
+++ b/melatonin/component_model.h
@@ -22,6 +22,12 @@ namespace melatonin
         juce::Value lookAndFeelValue, typeValue, fontValue, alphaValue;
         juce::Value pickedColor;
         juce::Value timing1, timing2, timing3, timingMax, hasChildren;
+
+        struct AccessiblityDetail
+        {
+            juce::Value title, value, role, handlerType;
+        } accessiblityDetail;
+
         double timingWithChildren1, timingWithChildren2, timingWithChildren3, timingWithChildrenMax;
 
         ComponentModel() = default;
@@ -144,6 +150,65 @@ namespace melatonin
             accessibilityHandledValue.addListener (this);
             interceptsMouseValue.addListener (this);
             childrenInterceptsMouseValue.addListener (this);
+
+            if (selectedComponent->isAccessible() && selectedComponent->getAccessibilityHandler())
+            {
+                auto* accH = selectedComponent->getAccessibilityHandler();
+                accessiblityDetail.handlerType = type (*accH);
+                if (accH->getValueInterface())
+                {
+                    accessiblityDetail.value = accH->getValueInterface()->getCurrentValueAsString();
+                }
+                else
+                {
+                    accessiblityDetail.value = "no value interface";
+                }
+                accessiblityDetail.title = accH->getTitle();
+                auto role = accH->getRole();
+                switch (role)
+                {
+                    // Amazingly juce doesn' thave a display name fn for these
+#define DN(x)                          \
+    case juce::AccessibilityRole::x:   \
+        accessiblityDetail.role = #x; \
+        break;
+                    DN (button)
+                    DN (toggleButton)
+                    DN (radioButton)
+                    DN (comboBox)
+                    DN (image)
+                    DN (slider)
+                    DN (label)
+                    DN (staticText)
+                    DN (editableText)
+                    DN (menuItem)
+                    DN (menuBar)
+                    DN (popupMenu)
+                    DN (table)
+                    DN (tableHeader)
+                    DN (column)
+                    DN (row)
+                    DN (cell)
+                    DN (hyperlink)
+                    DN (list)
+                    DN (listItem)
+                    DN (tree)
+                    DN (treeItem)
+                    DN (progressBar)
+                    DN (group)
+                    DN (dialogWindow)
+                    DN (window)
+                    DN (scrollBar)
+                    DN (tooltip)
+                    DN (splashScreen)
+                    DN (ignored)
+                    DN (unspecified)
+#undef DN
+                    default:
+                        accessiblityDetail.role = juce::String ("Unknown ") + juce::String ((int) role);
+                        break;
+                }
+            }
 
             {
                 bool interceptsMouse = false;

--- a/melatonin/components/properties.h
+++ b/melatonin/components/properties.h
@@ -68,6 +68,22 @@ namespace melatonin
             }
             panel.addProperties (props, padding);
 
+            if (model.accessibilityHandledValue.getValue())
+            {
+                auto& ad = model.accessiblityDetail;
+                auto aprops = juce::Array<juce::PropertyComponent*> {
+                    new juce::TextPropertyComponent (ad.title, "Title", 200, false, false),
+                    new juce::TextPropertyComponent (ad.value, "Value", 200, false, false),
+                    new juce::TextPropertyComponent (ad.role, "Role", 200, false, false),
+                    new juce::TextPropertyComponent (ad.handlerType, "Handler", 200, false, false),
+                };
+                for (auto* p : aprops)
+                {
+                    p->setLookAndFeel (&getLookAndFeel());
+                }
+                panel.addSection ("Accessibility", aprops);
+            }
+
             resized();
         }
 

--- a/melatonin/helpers/component_helpers.h
+++ b/melatonin/helpers/component_helpers.h
@@ -49,6 +49,19 @@ namespace melatonin
             return juce::String ("Editor: ") + editor->getAudioProcessor()->getName();
         }
 #endif
+        else if (c && c->isAccessible() && c->getAccessibilityHandler() && !c->getAccessibilityHandler()->getTitle().isEmpty())
+        {
+            // If a widget has an accessible name, prefer that to the internal
+            // name since it is user facing in a screen reader
+            auto acctitle = c->getAccessibilityHandler()->getTitle();
+            auto nm = c->getName();
+            if (nm != acctitle &&  !nm.isEmpty())
+            {
+                // but if i also have an internal name, dont' suppress it
+                acctitle += "(name=" + nm + ")";
+            }
+            return acctitle;
+        }
         else if (c && !c->getName().isEmpty())
         {
             return c->getName();


### PR DESCRIPTION
This change does two things

1. If a widget is accessible with a title, use that title for the melatonin sidebar rather than clasname and preferentially over juce name. (If it has both an accessible title and juce name and they differ the juce name is shown additionally)

2. collect and display basic accessible info in the inspector panel. these are title, type, value, and handler class.