### PR TITLE
Unsubscribe Accessibility from model in destructor. Fixes #109.

### DIFF
--- a/melatonin/components/accesibility.h
+++ b/melatonin/components/accesibility.h
@@ -13,6 +13,11 @@ namespace melatonin
             model.addListener (*this);
         }
 
+        ~Accessibility() override
+        {
+            model.removeListener (*this);
+        }
+
         void updateProperties()
         {
             panel.clear();


### PR DESCRIPTION
Accessibility subscribed to the model, but didn't unsubscribe in the destructor resulting in being called while not longer valid. Fixed #109 