### PR TITLE
Make copy of stringified value when displaying properties with Object values

### DIFF
--- a/melatonin/components/properties.h
+++ b/melatonin/components/properties.h
@@ -99,7 +99,10 @@ namespace melatonin
                 }
                 else if (!propertiesToIgnore.contains (nv.name))
                 {
-                    auto customProperty = new juce::TextPropertyComponent (nv.value, nv.name, 200, false);
+                    const auto value = nv.value.getValue().isObject()
+                                           ? juce::Value (nv.value.getValue().toString())
+                                           : nv.value;
+                    auto customProperty = new juce::TextPropertyComponent (value, nv.name, 200, false);
                     customProperty->getProperties().set ("isUserProperty", true);
                     props.add (customProperty);
                 }


### PR DESCRIPTION
Fixes a bug where Component properties with Object values would get turned into strings due to the use of `juce::TextPropertyComponent` and shared values.

To reproduce:

- Create a `juce::Component`.
- Set an Object property on the component, (you can use any type that inherits from `juce::ReferenceCountedObject`, e.g. a `juce::DynamicObject`).
- Inspect the component with the Inspector such that its properties are shown in the list
- The Object has been destroyed and replaced with a string in the form `"Object 0xabc"`

```cpp
juce::Component component;
component.getProperties().set("foo", new juce::DynamicObject{});
jassert(component.getProperties()["foo"].isObject()); // TRUE
jassert(component.getProperties()["foo"].isString()); // FALSE

// Inspect component with the inspector...

jassert(component.getProperties()["foo"].isObject()); // FALSE
jassert(component.getProperties()["foo"].isString()); // TRUE
```

This is due to how `juce::TextPropertyComponent` uses `juce::Value` - when it goes to display the value, it sets the text of it's `juce::Label` to the stringified version of the object. This causes a listener-change callback in the `juce::Value` that the label refers to which causes the underlying `juce::var`, originally in the component's properties list, to also be turned into a string.

The proposed solution here is to simply make a copy of the stringified value if the value is an object type.