### PR TITLE
Centralize font picking into InspectorLookAndFeel

### DIFF
--- a/melatonin/components/collapsable_panel.h
+++ b/melatonin/components/collapsable_panel.h
@@ -67,11 +67,7 @@ namespace melatonin
 
             void drawToggleButton (juce::Graphics& g, juce::ToggleButton& button, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override
             {
-               #if JUCE_MAJOR_VERSION == 8
-                auto font = juce::FontOptions ("Verdana", 14.5, juce::Font::FontStyleFlags::plain).withKerningFactor (0.1f);
-               #else
-                auto font = juce::Font ("Verdana", 14.5, juce::Font::FontStyleFlags::plain).withExtraKerningFactor (0.1f);
-               #endif
+                auto font = InspectorLookAndFeel::getInspectorFont (14.5, juce::Font::FontStyleFlags::plain).withExtraKerningFactor (0.1f);
                 auto tickWidth = font.getHeight();
 
                 drawTickBox (g, button, 6.0f, ((float) button.getHeight() - tickWidth) * 0.5f, tickWidth, tickWidth, button.getToggleState(), button.isEnabled(), shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);

--- a/melatonin/components/color_picker.h
+++ b/melatonin/components/color_picker.h
@@ -23,11 +23,7 @@ namespace melatonin
             g.setColour (colors::customBackground);
             g.fillRoundedRectangle (getLocalBounds().withSizeKeepingCentre (38, 16).toFloat(), 3);
             g.setColour (colors::label);
-           #if JUCE_MAJOR_VERSION == 8
-            g.setFont (juce::FontOptions ("Verdana", 9, juce::Font::FontStyleFlags::bold));
-           #else
-            g.setFont (juce::Font ("Verdana", 9, juce::Font::FontStyleFlags::bold));
-           #endif
+            g.setFont (InspectorLookAndFeel::getInspectorFont (9, juce::Font::FontStyleFlags::bold));
             g.drawText (rgba ? "RGBA" : "HEX", getLocalBounds(), juce::Justification::centred);
         }
 
@@ -102,22 +98,14 @@ namespace melatonin
                 g.fillRoundedRectangle (colorValueBounds.withTrimmedBottom (1).toFloat(), 4);
 
                 g.setColour (colors::text);
-               #if JUCE_MAJOR_VERSION == 8
-                g.setFont (juce::FontOptions ("Verdana", 14.5, juce::Font::FontStyleFlags::plain));
-               #else
-                g.setFont (juce::Font ("Verdana", 14.5, juce::Font::FontStyleFlags::plain));
-               #endif
+                g.setFont (InspectorLookAndFeel::getInspectorFont (14.5, juce::Font::FontStyleFlags::plain));
                 g.drawText (stringForColor (selectedColor), colorValueBounds.withTrimmedBottom (2), juce::Justification::centred);
             }
 
             if (model.colors.empty())
             {
                 g.setColour (colors::propertyName);
-               #if JUCE_MAJOR_VERSION == 8
-                g.setFont (juce::FontOptions ("Verdana", 15, juce::Font::FontStyleFlags::plain));
-               #else
-                g.setFont (juce::Font ("Verdana", 15, juce::Font::FontStyleFlags::plain));
-               #endif
+                g.setFont (InspectorLookAndFeel::getInspectorFont (15, juce::Font::FontStyleFlags::plain));
                 g.drawText ("No Color Properties", panelBounds.withTrimmedLeft (3).withTrimmedTop (2), juce::Justification::topLeft);
             }
         }

--- a/melatonin/components/component_tree_view_item.h
+++ b/melatonin/components/component_tree_view_item.h
@@ -128,11 +128,7 @@ namespace melatonin
                 g.setColour (colors::treeItemTextDisabled);
 
             auto name = componentString (component);
-           #if JUCE_MAJOR_VERSION == 8
-            auto font = juce::FontOptions ("Verdana", 15, juce::Font::FontStyleFlags::plain);
-           #else
-            auto font = juce::Font ("Verdana", 15, juce::Font::FontStyleFlags::plain);
-           #endif
+            auto font = InspectorLookAndFeel::getInspectorFont (15, juce::Font::FontStyleFlags::plain);
 
             g.setFont (font);
 

--- a/melatonin/components/preview.h
+++ b/melatonin/components/preview.h
@@ -19,11 +19,7 @@ namespace melatonin
             addAndMakeVisible (timingToggle);
             maxLabel.setColour (juce::Label::textColourId, colors::iconOff);
             maxLabel.setJustificationType (juce::Justification::centredTop);
-           #if JUCE_MAJOR_VERSION == 8
-            maxLabel.setFont (juce::FontOptions ("Verdana", 18, juce::Font::FontStyleFlags::bold));
-           #else
-            maxLabel.setFont (juce::Font ("Verdana", 18, juce::Font::FontStyleFlags::bold));
-           #endif
+            maxLabel.setFont (InspectorLookAndFeel::getInspectorFont (18, juce::Font::FontStyleFlags::bold));
 
             // by default timings aren't on
             timingToggle.on = settings->props->getBoolValue ("showPerformanceTimings", false);

--- a/melatonin/inspector_component.h
+++ b/melatonin/inspector_component.h
@@ -81,11 +81,7 @@ namespace melatonin
             tree.getViewport()->setScrollBarThickness (20);
 
             searchBox.setHelpText ("search");
-           #if JUCE_MAJOR_VERSION == 8
-            searchBox.setFont (juce::FontOptions ("Verdana", 17, juce::Font::FontStyleFlags::plain));
-           #else
-            searchBox.setFont (juce::Font ("Verdana", 17, juce::Font::FontStyleFlags::plain));
-           #endif
+            searchBox.setFont (InspectorLookAndFeel::getInspectorFont (17, juce::Font::FontStyleFlags::plain));
             searchBox.setColour (juce::Label::backgroundColourId, juce::Colours::transparentBlack);
             searchBox.setColour (juce::Label::textColourId, colors::treeItemTextSelected);
             searchBox.setColour (juce::TextEditor::outlineColourId, juce::Colours::transparentBlack);

--- a/melatonin/lookandfeel.h
+++ b/melatonin/lookandfeel.h
@@ -96,11 +96,7 @@ namespace melatonin
         // don't use the target app's font
         juce::Font getLabelFont (juce::Label& label) override
         {
-           #if JUCE_MAJOR_VERSION == 8
-            return juce::FontOptions { "Verdana", label.getFont().getHeight(), label.getFont().getStyleFlags() };
-           #else
-            return { "Verdana", label.getFont().getHeight(), label.getFont().getStyleFlags() };
-           #endif
+            return getInspectorFont(label.getFont().getHeight(), label.getFont().getStyleFlags());
         }
 
         // oh i dream of css resets...
@@ -232,6 +228,27 @@ namespace melatonin
             g.setColour (colors::highlight.withAlpha (0.7f));
             g.strokePath (path, juce::PathStrokeType (2.0f));
         }
-    };
 
+        static juce::Font getInspectorFont(float fontHeight, int styleFlags) {
+            static juce::String inspectorFont;
+            if (inspectorFont.isEmpty ()) {
+               #if JUCE_MAJOR_VERSION == 8
+                juce::Font testFont = juce::FontOptions { "Verdana", 12, juce::Font::FontStyleFlags::plain };
+               #else
+                juce::Font testFont = { "Verdana", 12, juce::Font::FontStyleFlags::plain }
+               #endif
+                if (juce::Typeface::createSystemTypefaceFor (testFont)) {
+                    inspectorFont = "Verdana";
+                } else {
+                    inspectorFont = juce::Font::getDefaultSansSerifFontName ();
+                }
+            }
+           #if JUCE_MAJOR_VERSION == 8
+            return juce::FontOptions { inspectorFont, fontHeight, styleFlags };
+           #else
+            return { inspectorFont, fontHeight, styleFlags };
+           #endif
+
+        }
+    };
 }


### PR DESCRIPTION
This allows us to easily use a fall-back if Verdana isn't available (for example on many Linux systems).

This addresses https://github.com/sudara/melatonin_inspector/issues/120