### PR TITLE
Handle JUCE 8.0.2 deprecating `Font::getStringWidth()`

### DIFF
--- a/melatonin/components/overlay.h
+++ b/melatonin/components/overlay.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../helpers/misc.h"
+#include "../lookandfeel.h"
 
 namespace melatonin
 {
@@ -351,7 +352,7 @@ namespace melatonin
 
         void drawDimensionsLabel()
         {
-            int labelWidth = (int) dimensions.getFont().getStringWidthFloat (dimensionsString (selectedBounds)) + 15;
+            int labelWidth = (int) InspectorLookAndFeel::getStringWidth (dimensions.getFont(), dimensionsString (selectedBounds)) + 15;
             int labelHeight = 15;
             auto paddingToLabel = 4;
             auto labelCenterX = selectedBounds.getX() + selectedBounds.getWidth() / 2;
@@ -413,7 +414,7 @@ namespace melatonin
                 // top
                 if (lineToTopHoveredComponent.getLength() > 0)
                 {
-                    int labelWidth = (int) distanceToTopHoveredLabel.getFont().getStringWidthFloat (distanceString (lineToTopHoveredComponent)) + 15;
+                    int labelWidth = (int) InspectorLookAndFeel::getStringWidth (distanceToTopHoveredLabel.getFont(), distanceString (lineToTopHoveredComponent)) + 15;
 
                     // todo draw on left or right side of line
                     auto labelCenterY = lineToTopHoveredComponent.getPointAlongLineProportionally (0.5f).getY();
@@ -429,7 +430,7 @@ namespace melatonin
                 // bottom
                 if (lineToBottomHoveredComponent.getLength() > 0)
                 {
-                    int labelWidth = (int) distanceToBottomHoveredLabel.getFont().getStringWidthFloat (distanceString (lineToBottomHoveredComponent)) + 15;
+                    int labelWidth = (int) InspectorLookAndFeel::getStringWidth (distanceToBottomHoveredLabel.getFont(), distanceString (lineToBottomHoveredComponent)) + 15;
 
                     // todo draw on left or right side of line
                     auto labelCenterY = lineToBottomHoveredComponent.getPointAlongLineProportionally (0.5f).getY();
@@ -445,7 +446,7 @@ namespace melatonin
                 // right
                 if (lineToRightHoveredComponent.getLength() > 0)
                 {
-                    int labelWidth = (int) distanceToRightHoveredLabel.getFont().getStringWidthFloat (distanceString (lineToRightHoveredComponent)) + 15;
+                    int labelWidth = (int) InspectorLookAndFeel::getStringWidth (distanceToRightHoveredLabel.getFont(), distanceString (lineToRightHoveredComponent)) + 15;
 
                     // todo draw on top or bottom side of line
                     auto labelCenterX = lineToRightHoveredComponent.getPointAlongLineProportionally (0.5f).getX();
@@ -461,7 +462,7 @@ namespace melatonin
                 // left
                 if (lineToLeftHoveredComponent.getLength() > 0)
                 {
-                    int labelWidth = (int) distanceToLeftHoveredLabel.getFont().getStringWidthFloat (distanceString (lineToLeftHoveredComponent)) + 15;
+                    int labelWidth = (int) InspectorLookAndFeel::getStringWidth (distanceToLeftHoveredLabel.getFont(), distanceString (lineToLeftHoveredComponent)) + 15;
 
                     // todo draw on top or bottom side of line
                     auto labelCenterX = lineToLeftHoveredComponent.getPointAlongLineProportionally (0.5f).getX();

--- a/melatonin/lookandfeel.h
+++ b/melatonin/lookandfeel.h
@@ -96,7 +96,7 @@ namespace melatonin
         // don't use the target app's font
         juce::Font getLabelFont (juce::Label& label) override
         {
-            return getInspectorFont(label.getFont().getHeight(), label.getFont().getStyleFlags());
+            return getInspectorFont (label.getFont().getHeight(), label.getFont().getStyleFlags());
         }
 
         // oh i dream of css resets...
@@ -164,7 +164,7 @@ namespace melatonin
 
             if (component.getProperties().getWithDefault ("isUserProperty", false))
             {
-                auto textWidth = (float) g.getCurrentFont().getStringWidth (component.getName());
+                auto textWidth = getStringWidth (g.getCurrentFont(), component.getName());
                 auto tagBounds = juce::Rectangle<float> (3 + textWidth + 3, 7, 40, 14).toFloat();
                 g.setColour (colors::panelBackgroundDarker);
                 g.fillRoundedRectangle (tagBounds, 3);
@@ -249,6 +249,15 @@ namespace melatonin
             return { inspectorFont, fontHeight, styleFlags };
            #endif
 
+        }
+
+        static float getStringWidth (const juce::Font& font, const juce::String& text)
+        {
+#if JUCE_MAJOR_VERSION == 8 && JUCE_BUILDNUMBER >= 2
+            return juce::GlyphArrangement::getStringWidth (font, text);
+#else
+            return font.getStringWidthFloat (text);
+#endif
         }
     };
 }


### PR DESCRIPTION
JUCE deprecated `Font::getStringWidth()` in v8.0.2, which was used in a few places across the inspector.

This adds a new `getStringWidth()` static method to `InspectorLookAndFeel` which uses `juce::GlyphArrangement` to calculate the string width in JUCE 8.0.2 or newer, keeping backwards-compatibility for older versions of JUCE.