### PR TITLE
Adds Style component to display Juce build-in widget Styles: i.e. SliderType, TextPosition

### DIFF
--- a/melatonin/components/style_component.h
+++ b/melatonin/components/style_component.h
@@ -9,6 +9,7 @@ namespace melatonin
         explicit StyleProperties(ComponentModel& _model) : model(_model)
         {
             reset();
+
             addAndMakeVisible(&panel);
             model.addListener(*this);
         }
@@ -20,6 +21,7 @@ namespace melatonin
 
         void resized() override
         {
+            TRACE_COMPONENT();
             panel.setBounds(getLocalBounds().withTrimmedTop(padding));
         }
 
@@ -41,6 +43,7 @@ namespace melatonin
 
         void updateProperties()
         {
+            TRACE_COMPONENT();
             panel.clear();
 
             if (!model.getSelectedComponent())
@@ -58,6 +61,7 @@ namespace melatonin
 
         [[nodiscard]] juce::Array<juce::PropertyComponent*> createStylePropertyComponents() const
         {
+            TRACE_COMPONENT();
             juce::Array<juce::PropertyComponent*> props;
 
             for (const auto& style : model.styles)
@@ -68,19 +72,19 @@ namespace melatonin
                     juce::Array<juce::var> optionIndices;
                     for (int i = 0; i < style.options.size(); ++i)
                         optionIndices.add(i);
-
-                    props.add(new juce::ChoicePropertyComponent(
+                    auto choiceComp = new juce::ChoicePropertyComponent(
                         style.value,
-                        style.name,
+                        style.getDisplayName(),
                         style.options,
-                        optionIndices));
+                        optionIndices);
+                    props.add(choiceComp);
                 }
                 else if (style.value.getValue().isBool())
                 {
                     // For boolean properties
                     props.add(new juce::BooleanPropertyComponent(
                         style.value,
-                        style.name,
+                        style.getDisplayName(),
                         ""));
                 }
                 else
@@ -88,7 +92,7 @@ namespace melatonin
                     // For text/numeric properties
                     props.add(new juce::TextPropertyComponent(
                         style.value,
-                        style.name,
+                        style.getDisplayName(),
                         50,
                         false));
                 }

--- a/melatonin/components/style_component.h
+++ b/melatonin/components/style_component.h
@@ -1,0 +1,102 @@
+#pragma once
+#include "melatonin_inspector/melatonin/component_model.h"
+
+namespace melatonin
+{
+    class StyleProperties : public juce::Component, private ComponentModel::Listener
+    {
+    public:
+        explicit StyleProperties(ComponentModel& _model) : model(_model)
+        {
+            reset();
+            addAndMakeVisible(&panel);
+            model.addListener(*this);
+        }
+
+        ~StyleProperties() override
+        {
+            model.removeListener(*this);
+        }
+
+        void resized() override
+        {
+            panel.setBounds(getLocalBounds().withTrimmedTop(padding));
+        }
+
+        void reset()
+        {
+            updateProperties();
+            resized();
+        }
+
+    private:
+        ComponentModel& model;
+        juce::PropertyPanel panel{"Style Properties"};
+        int padding = 3;
+
+        void componentModelChanged(ComponentModel&) override
+        {
+            updateProperties();
+        }
+
+        void updateProperties()
+        {
+            panel.clear();
+
+            if (!model.getSelectedComponent())
+                return;
+
+            auto props = createStylePropertyComponents();
+            for (auto* p : props)
+            {
+                p->setLookAndFeel(&getLookAndFeel());
+            }
+            panel.addProperties(props, padding);
+
+            resized();
+        }
+
+        [[nodiscard]] juce::Array<juce::PropertyComponent*> createStylePropertyComponents() const
+        {
+            juce::Array<juce::PropertyComponent*> props;
+
+            for (const auto& style : model.styles)
+            {
+                if (!style.options.isEmpty())
+                {
+                    // For enumerated/choice properties
+                    juce::Array<juce::var> optionIndices;
+                    for (int i = 0; i < style.options.size(); ++i)
+                        optionIndices.add(i);
+
+                    props.add(new juce::ChoicePropertyComponent(
+                        style.value,
+                        style.name,
+                        style.options,
+                        optionIndices));
+                }
+                else if (style.value.getValue().isBool())
+                {
+                    // For boolean properties
+                    props.add(new juce::BooleanPropertyComponent(
+                        style.value,
+                        style.name,
+                        ""));
+                }
+                else
+                {
+                    // For text/numeric properties
+                    props.add(new juce::TextPropertyComponent(
+                        style.value,
+                        style.name,
+                        50,
+                        false));
+                }
+            }
+
+            return props;
+        }
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(StyleProperties)
+    };
+}

--- a/melatonin/inspector_component.h
+++ b/melatonin/inspector_component.h
@@ -279,7 +279,7 @@ namespace melatonin
             int numOfStyleToDisplay = juce::jlimit (0, 5, (int) model.styles.size());
             auto stylePropertiesHeight = 32;
             if (styleProperties.isVisible() && !model.styles.empty())
-                stylePropertiesHeight += 24 * numOfStyleToDisplay;
+                stylePropertiesHeight += 32 * numOfStyleToDisplay;
             auto stylePropertiesBounds = mainCol.removeFromTop (stylePropertiesHeight);
             stylePanel.setBounds (stylePropertiesBounds.removeFromTop (32).removeFromLeft (200));
             styleProperties.setBounds (stylePropertiesBounds.withTrimmedLeft (32));

--- a/melatonin/inspector_component.h
+++ b/melatonin/inspector_component.h
@@ -8,6 +8,7 @@
 #include "melatonin_inspector/melatonin/components/component_tree_view_item.h"
 #include "melatonin_inspector/melatonin/components/preview.h"
 #include "melatonin_inspector/melatonin/components/properties.h"
+#include "melatonin_inspector/melatonin/components/style_component.h"
 #include "melatonin_inspector/melatonin/lookandfeel.h"
 
 /*
@@ -42,6 +43,7 @@ namespace melatonin
             addChildComponent (colorPicker);
             addChildComponent (preview);
             addChildComponent (properties);
+            addChildComponent (styleProperties);
             addChildComponent (accessibility);
 
             // z-order on panels is higher so they are clickable
@@ -49,6 +51,7 @@ namespace melatonin
             addAndMakeVisible (colorPickerPanel);
             addAndMakeVisible (previewPanel);
             addAndMakeVisible (propertiesPanel);
+            addAndMakeVisible (stylePanel);
             addAndMakeVisible (accessibilityPanel);
 
             addAndMakeVisible (searchBox);
@@ -273,6 +276,14 @@ namespace melatonin
             colorPicker.setBounds (colorPickerBounds.withTrimmedLeft (32));
             colorPickerPanel.setBounds (colorPickerBounds.removeFromTop (32).removeFromLeft (200));
 
+            int numOfStyleToDisplay = juce::jlimit (0, 5, (int) model.styles.size());
+            auto stylePropertiesHeight = 32;
+            if (styleProperties.isVisible() && !model.styles.empty())
+                stylePropertiesHeight += 24 * numOfStyleToDisplay;
+            auto stylePropertiesBounds = mainCol.removeFromTop (stylePropertiesHeight);
+            stylePanel.setBounds (stylePropertiesBounds.removeFromTop (32).removeFromLeft (200));
+            styleProperties.setBounds (stylePropertiesBounds.withTrimmedLeft (32));
+
             accessibilityPanel.setBounds (mainCol.removeFromTop (32));
             accessibility.setBounds (mainCol.removeFromTop (accessibility.isVisible() ? 110 : 0).withTrimmedLeft (32));
 
@@ -347,6 +358,7 @@ namespace melatonin
             tree.clearSelectedItems();
 
             properties.reset();
+            styleProperties.reset();
             model.deselectComponent();
             tree.setRootItem (getRoot());
 
@@ -370,6 +382,7 @@ namespace melatonin
             previewPanel.setVisible (nowEnabled);
             colorPickerPanel.setVisible (nowEnabled);
             propertiesPanel.setVisible (nowEnabled);
+            stylePanel.setVisible(nowEnabled);
             tree.setVisible (nowEnabled);
 
             if (!nowEnabled)
@@ -418,6 +431,9 @@ namespace melatonin
 
         Properties properties { model };
         CollapsablePanel propertiesPanel { "PROPERTIES", &properties, true };
+
+        StyleProperties styleProperties { model };
+        CollapsablePanel stylePanel { "STYLE", &styleProperties, false };
 
         Accessibility accessibility { model };
         CollapsablePanel accessibilityPanel { "ACCESSIBILITY", &accessibility, false };

--- a/melatonin/lookandfeel.h
+++ b/melatonin/lookandfeel.h
@@ -38,6 +38,11 @@ namespace melatonin
             setColour (juce::BooleanPropertyComponent::backgroundColourId, juce::Colours::transparentBlack);
             setColour (juce::BooleanPropertyComponent::outlineColourId, juce::Colours::transparentBlack);
 
+            setColour (juce::ChoicePropertyComponent::backgroundColourId, juce::Colours::transparentBlack);
+            setColour (juce::ChoicePropertyComponent::labelTextColourId, colors::propertyValue);
+            setColour (juce::ComboBox::backgroundColourId, juce::Colours::transparentBlack);
+            setColour (juce::PopupMenu::backgroundColourId, colors::headerBackground);
+
             // this is transparent so that we can paint it in our item
             setColour (juce::TreeView::ColourIds::selectedItemBackgroundColourId, colors::black.withAlpha (0.0f));
             setColour (juce::TreeView::ColourIds::backgroundColourId, juce::Colours::transparentBlack);
@@ -52,6 +57,7 @@ namespace melatonin
             setColour (juce::TextEditor::highlightColourId, colors::highlightedText);
             setColour (juce::Slider::textBoxBackgroundColourId, juce::Colours::transparentBlack);
             setColour (juce::Slider::textBoxHighlightColourId, colors::highlightedText);
+            setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::transparentBlack);
             setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::transparentBlack);
         }
 


### PR DESCRIPTION
Initial intention was to display SliderStyle, but why not to expand it to more widget types? And also I would like to allow preview different options.

This is still WIP. 

https://github.com/user-attachments/assets/1ef8687e-bf60-499e-b396-07bc6e5c7c67

