### PR TITLE
Check that MELATONIN_VBLANK is already defined.

### DIFF
--- a/melatonin/components/fps_meter.h
+++ b/melatonin/components/fps_meter.h
@@ -4,7 +4,9 @@
 
 // VBlank was added in 7.0.3
 #if (JUCE_MAJOR_VERSION >= 7) && (JUCE_MINOR_VERSION >= 1 || JUCE_BUILDNUMBER >= 3)
+    #ifndef MELATONIN_VBLANK
     #define MELATONIN_VBLANK 1
+    #endif
 #else
     #define MELATONIN_VBLANK 0
 #endif


### PR DESCRIPTION
Fixes #131 when you set `#define MELATONIN_VBLANK 0` before the include