### PR TITLE
Moves FPS meter to be displayed on top of GUI

### DIFF
--- a/melatonin/components/fps_meter.h
+++ b/melatonin/components/fps_meter.h
@@ -22,6 +22,7 @@ namespace melatonin
             // unfortunately, on macOS, this no longer works
             // See FAQ in README for more info
             setOpaque (true);
+            setAlwaysOnTop(true);
 
             setInterceptsMouseClicks (false, false);
         }


### PR DESCRIPTION
FPS Meter is covered by other components, setting this flag fixes makes sure it always visible. 

<img width="106" height="81" alt="Screenshot 2025-07-09 at 9 10 39 PM" src="https://github.com/user-attachments/assets/c5e325b3-86c2-4ea3-8198-201b77d1902d" />
