### PR TITLE
Minor GUI | Fixed off state icon toggle btn is cropped on the left

### DIFF
--- a/melatonin/lookandfeel.h
+++ b/melatonin/lookandfeel.h
@@ -109,7 +109,7 @@ namespace melatonin
         void drawToggleButton (juce::Graphics& g, juce::ToggleButton& button, bool /*shouldDrawButtonAsHighlighted*/, bool /*shouldDrawButtonAsDown*/) override
         {
             float toggleWidth = 14;
-            float leftPadding = 0;
+            float leftPadding = 2;
 
             juce::Rectangle<float> bounds (leftPadding, (float) button.getHeight() / 2 - toggleWidth / 2.f, toggleWidth, toggleWidth);
 


### PR DESCRIPTION
Before:
<img width="338" height="307" alt="Screenshot 2025-10-19 at 10 43 32 AM" src="https://github.com/user-attachments/assets/ec3697e2-1907-45fc-a316-20329eb2ba2b" />

After:

<img width="342" height="196" alt="Screenshot 2025-10-19 at 10 50 16 AM" src="https://github.com/user-attachments/assets/2e86ec25-9792-45e6-8010-eb715d4f3166" />
